### PR TITLE
 	Add support for selecting the Rust release channel

### DIFF
--- a/lib/docs-resolver.coffee
+++ b/lib/docs-resolver.coffee
@@ -15,10 +15,11 @@ module.exports = DocsResolver =
   assertModulePageAvailability: (path, callback) -> @assertPageAvailability(path, "$1/index.html", callback)
 
   assertPageAvailability: (path, resourceEndFormat, callback) ->
+    c = atom.config.get('rust-api-docs-helper.rustReleaseChannel')
     p = path.replace(/(\w*?)$/, resourceEndFormat)
     req = new XMLHttpRequest()
     req.onloadend = @onLoadEnd(path, @cache, callback)
-    req.open("HEAD","http://doc.rust-lang.org/#{p}")
+    req.open("HEAD","http://doc.rust-lang.org/#{c}/#{p}")
     req.send()
 
   onLoadEnd: (path, cache, callback) -> (e) ->

--- a/lib/rust-api-docs-helper.coffee
+++ b/lib/rust-api-docs-helper.coffee
@@ -32,7 +32,7 @@ module.exports = RustApiDocsHelper =
     rustReleaseChannel:
       type:'string'
       description: """
-                      Identifies which release channel to when providing documentation.
+                      Identifies which release channel to use when providing documentation.
                    """
       default: 'stable'
       enum: ['stable', 'beta', 'nightly']

--- a/lib/rust-api-docs-helper.coffee
+++ b/lib/rust-api-docs-helper.coffee
@@ -29,6 +29,13 @@ module.exports = RustApiDocsHelper =
                       There is a bug at the moment that causes errors with this function.
                    """
       default: true
+    rustReleaseChannel:
+      type:'string'
+      description: """
+                      Identifies which release channel to when providing documentation.
+                   """
+      default: 'stable'
+      enum: ['stable', 'beta', 'nightly']
 
   subscriptions: null
 


### PR DESCRIPTION
- Added a `rustReleaseChannel` enum to the config options.
- Modified the `assertPageAvailability` function to use
  the enum when constructing the documentation's URL.
