### PR TITLE
Resolving 'type' and 'enum', Allow choosing the channel of the documents

### DIFF
--- a/lib/docs-resolver.coffee
+++ b/lib/docs-resolver.coffee
@@ -15,10 +15,11 @@ module.exports = DocsResolver =
   assertModulePageAvailability: (path, callback) -> @assertPageAvailability(path, "$1/index.html", callback)
 
   assertPageAvailability: (path, resourceEndFormat, callback) ->
+    channel = atom.config.get('rust-api-docs-helper.rustChannel')
     p = path.replace(/(\w*?)$/, resourceEndFormat)
     req = new XMLHttpRequest()
     req.onloadend = @onLoadEnd(path, @cache, callback)
-    req.open("HEAD","http://doc.rust-lang.org/#{p}")
+    req.open("HEAD","http://doc.rust-lang.org/#{channel}/#{p}")
     req.send()
 
   onLoadEnd: (path, cache, callback) -> (e) ->

--- a/lib/docs-resolver.coffee
+++ b/lib/docs-resolver.coffee
@@ -8,7 +8,7 @@ module.exports = DocsResolver =
       @searchMathingDocs(path, callback)
 
   searchMathingDocs: (path, callback) ->
-    for objectType in ['struct','trait','fn']
+    for objectType in ['type','enum','struct','trait','fn']
       @assertPageAvailability(path, "#{objectType}.$1.html", callback)
     @assertModulePageAvailability(path, callback)
 

--- a/lib/rust-api-docs-helper.coffee
+++ b/lib/rust-api-docs-helper.coffee
@@ -7,6 +7,13 @@ Shell                   = require 'shell'
 
 module.exports = RustApiDocsHelper =
   config:
+    rustChannel:
+      type: 'string'
+      description: """
+                      The distribution channel from which the document will be searched
+                   """
+      enum: ['stable','beta','nightly']
+      default: 'stable'
     useInternalBrowser:
       type:'boolean'
       description: """If set, a URL open request will be sent, that will attempt to open the docs URL within atom,


### PR DESCRIPTION
I found myself needing to see the type and enum documents as well
